### PR TITLE
⚠️ loading in progress, circular require considered harmful

### DIFF
--- a/lib/error_page_assets/railtie.rb
+++ b/lib/error_page_assets/railtie.rb
@@ -1,4 +1,3 @@
-require 'error_page_assets'
 require 'rails'
 
 module ErrorPageAssets


### PR DESCRIPTION
This patch eliminates circular require warning.

This require can be safely removed because `require 'error_page_assets'` should already be performed by bundler.