### PR TITLE
Avoid method leaked into global namespace

### DIFF
--- a/lib/rake/error_page_assets_task.rb
+++ b/lib/rake/error_page_assets_task.rb
@@ -1,0 +1,59 @@
+require 'rake'
+require 'rake/tasklib'
+require 'fileutils'
+
+module Rake
+  class ErrorPageAssetsTask < Rake::TaskLib
+    attr_accessor :name
+
+    def initialize(name = :error_pages, task_dependencies = [])
+      self.name = name
+
+      yield self if block_given?
+
+      define
+    end
+
+    def log msg
+      # try to log like Sprockets even though their stuff is all private
+      STDERR.puts msg
+      Rails.logger.info(msg) if Rails.respond_to?(:logger) && Rails.logger
+    end
+
+    def process_error_files
+      config = Rails.configuration
+      pattern = File.join(config.paths['public'].first, config.assets.prefix, "[0-9][0-9][0-9]*.html")
+
+      groups = Dir[pattern].group_by { |s| File.basename(s)[0..2] }
+      groups.sort_by { |base,_| base }.each do |base, group|
+        src = group.sort_by { |f| File.mtime(f) }.last
+        dst = Rails.public_path.join("#{base}.html").to_s
+        yield src, dst
+      end
+    end
+
+    def define
+      namespace :assets do
+        namespace :precompile do
+          desc 'Copy the newest error page assets into /public'
+          task name do
+            process_error_files do |src, dst|
+              log "copy #{src} to #{dst}"
+              FileUtils.cp src, dst
+            end
+          end
+        end
+
+        namespace :clobber do
+          desc 'Remove the error page assets in /public'
+          task name do
+            process_error_files do |src,dst|
+              log "clobber #{dst}"
+              FileUtils.rm_f dst
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/error_page_assets.rake
+++ b/lib/tasks/error_page_assets.rake
@@ -1,53 +1,12 @@
-require 'fileutils'
+require 'rake/error_page_assets_task'
 
 # Use the Asset Pipeline to generate static error pages.
 # For example, /app/assets/html/404.html.erb will be compiled to /public/404.html
 
+Rake::ErrorPageAssetsTask.new
 
 Rake::Task['assets:precompile'].enhance do
   Rake::Task['assets:precompile:error_pages'].invoke
 end
 
 Rake::Task['assets:clobber'].enhance ['assets:clobber:error_pages']
-
-
-namespace :assets do
-  def log msg
-    # try to log like Sprockets even though their stuff is all private
-    STDERR.puts msg
-    Rails.logger.info(msg) if Rails.respond_to?(:logger) && Rails.logger
-  end
-
-  def process_error_files
-    config = Rails.configuration
-    pattern = File.join(config.paths['public'].first, config.assets.prefix, "[0-9][0-9][0-9]*.html")
-
-    groups = Dir[pattern].group_by { |s| File.basename(s)[0..2] }
-    groups.sort_by { |base,_| base }.each do |base, group|
-      src = group.sort_by { |f| File.mtime(f) }.last
-      dst = Rails.public_path.join("#{base}.html").to_s
-      yield src, dst
-    end
-  end
-
-  namespace :precompile do
-    desc 'Copy the newest error page assets into /public'
-    task :error_pages do
-      process_error_files do |src,dst|
-        log "copy #{src} to #{dst}"
-        FileUtils.cp src, dst
-      end
-    end
-  end
-
-  namespace :clobber do
-    desc 'Remove the error page assets in /public'
-    task :error_pages do
-      process_error_files do |src,dst|
-        log "clobber #{dst}"
-        FileUtils.rm_f dst
-      end
-    end
-  end
-end
-


### PR DESCRIPTION
Hello, @bronson 
First of all, thank you for making this little nice gem! We've been using this for a while and we recently encountered a method definition collision caused by the rake task of this library, and thus decided to fix the issue with this PR.

This should close #1.